### PR TITLE
Remove assumption for minutes.

### DIFF
--- a/_episodes/01-Crude-DNA-Isolation-from-Seeds.md
+++ b/_episodes/01-Crude-DNA-Isolation-from-Seeds.md
@@ -1,7 +1,7 @@
 ---
 title: "Crude DNA Isolation from Seeds"
-teaching: 30
-exercises: 30
+teaching: 30 minutes
+exercises: 30 minutes
 questions:
 - "How to crude DNA Isolation from seeds?"
 

--- a/_episodes/02-Micro-CTAB-DNA-Extration-Procedure-For-Fresh-Material.md
+++ b/_episodes/02-Micro-CTAB-DNA-Extration-Procedure-For-Fresh-Material.md
@@ -1,7 +1,7 @@
 ---
 title: "Micro-CTAB DNA Extraction Procedure for Fresh Material"
-teaching: 30
-exercises: 30
+teaching: 30 minutes
+exercises: 30 minutes
 questions:
 - "How to extract DNA from fresh pulse tissues?"
 

--- a/_episodes/03-KASP-PCR-Protocol.md
+++ b/_episodes/03-KASP-PCR-Protocol.md
@@ -1,7 +1,7 @@
 ---
 title: "PCR Program for KASP Assays"
-teaching: 30
-exercises: 30
+teaching: 30 minutes
+exercises: 30 minutes
 questions:
 - "How to use PCR program for KASP assays?"
 - "How to plot the data?"

--- a/_includes/episode_overview.html
+++ b/_includes/episode_overview.html
@@ -46,9 +46,9 @@
 
   <div class="row">
     <div class="col-md-3">
-      <strong>Teaching:</strong> {{ teaching_time }} min
+      <strong>Teaching:</strong> {{ teaching_time }}
       <br/>
-      <strong>Exercises:</strong> {{ exercise_time }} min
+      <strong>Exercises:</strong> {{ exercise_time }}
     </div>
     <div class="col-md-9">
       <strong>Questions</strong>


### PR DESCRIPTION
This PR will remove the assumption for minutes used in the estimated lesson times. This will only apply to this lesson!

I have already gone through and changed the other episodes to include the units in the teaching and exercise times. While I was at it I noticed that they're all 30 minutes? Was this estimate given by Rob and/or is it accurate? We should be careful with these numbers as people may use them to plan their time. The teaching time should be the amount of time it takes them to read through the episode carefully including following the links. The exercise time should be the amount of time it takes to do the actual experiment. @ruobinLiu can you look into this?